### PR TITLE
Compute deltaAddrUpper correctly in setAddress

### DIFF
--- a/CHERICC_Fat.bsv
+++ b/CHERICC_Fat.bsv
@@ -655,7 +655,7 @@ function VnD#(CapFat) setAddress(CapFat cap, CapAddr address, TempFields tf);
   Bit#(TSub#(CapAddrW,MW)) deltaAddrHi = signExtend({1'b0,pack(newAddrHi)} - {1'b0,pack(tf.addrHi)}) << e;
   // Calculate the actual difference between the upper bits of the new address and the original address.
   Bit#(TSub#(CapAddrW,MW)) mask = -1 << e;
-  Bit#(TSub#(CapAddrW,MW)) deltaAddrUpper = (truncateLSB(cap.address)&mask) - (truncateLSB(address)&mask);
+  Bit#(TSub#(CapAddrW,MW)) deltaAddrUpper = (truncateLSB(address)&mask) - (truncateLSB(cap.address)&mask);
   Bool inRepBounds = deltaAddrHi == deltaAddrUpper;
   if (!inRepBounds) ret.isCapability = False;
   return VnD {v: inRepBounds, d: ret};


### PR DESCRIPTION
The new version is formally verified to comply with the Sail specification.