### PR TITLE
Initial attempt at single cycle setBounds checking if the request is …

### DIFF
--- a/CHERICap.bsv
+++ b/CHERICap.bsv
@@ -104,6 +104,7 @@ typedef struct {
 typedef struct {
   capT cap;
   Bool exact;
+  Bool inBounds;
   Bit #(addrW) length;
   Bit #(addrW) mask;
 } SetBoundsReturn #(type capT, numeric type addrW) deriving (Bits, Eq, FShow);


### PR DESCRIPTION
…in bounds

This appears to be correct, except in the case where: new-base = new-top = old-top = 1<<Xlen, with an address near 0. In this case these fields are all set to 0 and the check succeeds. This needs further thought.