### PR TITLE
Refactor legalisation functions

### DIFF
--- a/CHERICC_Fat.bsv
+++ b/CHERICC_Fat.bsv
@@ -1527,8 +1527,7 @@ instance CHERICap #(CapReg, 0, 0, CapAddrW, CapW, TSub#(MW, 2));
          && (   (truncateLSB (cap.bounds.topBits)  != 1'b0)
              || (truncateLSB (cap.bounds.baseBits) != 2'b0) ))
     && !(   (cap.bounds.exp == resetExp-1)
-         && (truncateLSB (cap.bounds.baseBits) != 1'b0))
-    &&  hasLegalReservedBits(cap);
+         && (truncateLSB (cap.bounds.baseBits) != 1'b0));
 
 endinstance
 

--- a/CHERICC_Fat.bsv
+++ b/CHERICC_Fat.bsv
@@ -1347,6 +1347,7 @@ instance CHERICap #(CapMem, 0, 0, CapAddrW, CapW, TSub#(MW, 2));
   // Assert that the encoding is valid
   //////////////////////////////////////////////////////////////////////////////
   function hasLegalBounds = error ("hasLegalBounds not implemented for CapMem");
+  function hasLegalReservedBits = error ("hasLegalReservedBits not implemented for CapMem");
 
 endinstance
 
@@ -1514,6 +1515,12 @@ instance CHERICap #(CapReg, 0, 0, CapAddrW, CapW, TSub#(MW, 2));
 
   // Assert that the encoding is valid
   //////////////////////////////////////////////////////////////////////////////
+
+
+  function hasLegalReservedBits (cap) =
+        (cap.reserved_hi == 0)
+    &&  (cap.reserved_lo == 0);  
+  
   function hasLegalBounds (cap) =
         (cap.bounds.exp <= resetExp)
     && !(   (cap.bounds.exp == resetExp)
@@ -1521,8 +1528,7 @@ instance CHERICap #(CapReg, 0, 0, CapAddrW, CapW, TSub#(MW, 2));
              || (truncateLSB (cap.bounds.baseBits) != 2'b0) ))
     && !(   (cap.bounds.exp == resetExp-1)
          && (truncateLSB (cap.bounds.baseBits) != 1'b0))
-    &&  (cap.reserved_hi == 0)
-    &&  (cap.reserved_lo == 0);
+    &&  hasLegalReservedBits(cap);
 
 endinstance
 
@@ -1636,6 +1642,7 @@ instance CHERICap #(CapPipe, 0, 0, CapAddrW, CapW, TSub#(MW, 2));
     capInBounds(cap.capFat, cap.tempFields, inclusive);
 
   function hasLegalBounds (cap) = hasLegalBounds(cap.capFat);
+  function hasLegalReservedBits (cap) = hasLegalReservedBits(cap.capFat);
 
 endinstance
 

--- a/CHERICC_Fat.bsv
+++ b/CHERICC_Fat.bsv
@@ -1346,7 +1346,7 @@ instance CHERICap #(CapMem, 0, 0, CapAddrW, CapW, TSub#(MW, 2));
 
   // Assert that the encoding is valid
   //////////////////////////////////////////////////////////////////////////////
-  function isDerivable = error ("isDerivable not implemented for CapMem");
+  function hasLegalBounds = error ("hasLegalBounds not implemented for CapMem");
 
 endinstance
 
@@ -1514,7 +1514,7 @@ instance CHERICap #(CapReg, 0, 0, CapAddrW, CapW, TSub#(MW, 2));
 
   // Assert that the encoding is valid
   //////////////////////////////////////////////////////////////////////////////
-  function isDerivable (cap) =
+  function hasLegalBounds (cap) =
         (cap.bounds.exp <= resetExp)
     && !(   (cap.bounds.exp == resetExp)
          && (   (truncateLSB (cap.bounds.topBits)  != 1'b0)
@@ -1635,7 +1635,7 @@ instance CHERICap #(CapPipe, 0, 0, CapAddrW, CapW, TSub#(MW, 2));
   function isInBounds (cap, inclusive) =
     capInBounds(cap.capFat, cap.tempFields, inclusive);
 
-  function isDerivable (cap) = isDerivable(cap.capFat);
+  function hasLegalBounds (cap) = hasLegalBounds(cap.capFat);
 
 endinstance
 

--- a/CHERICap.bsv
+++ b/CHERICap.bsv
@@ -408,6 +408,7 @@ typeclass CHERICap #( type capT              // type of the CHERICap capability
 
   function Bool hasLegalBounds (capT cap);
 
+  // return whether hard perms, bounds, and int mode are legal
   function Bool isLegal (capT cap) =
        hasLegalHardPerms(cap)
     && hasLegalBounds(cap)

--- a/CHERICap.bsv
+++ b/CHERICap.bsv
@@ -408,6 +408,8 @@ typeclass CHERICap #( type capT              // type of the CHERICap capability
 
   function Bool hasLegalBounds (capT cap);
 
+  function Bool hasLegalReservedBits (capT cap);
+  
   // return whether hard perms, bounds, and int mode are legal
   function Bool isLegal (capT cap) =
        hasLegalHardPerms(cap)

--- a/CHERICap.bsv
+++ b/CHERICap.bsv
@@ -414,6 +414,7 @@ typeclass CHERICap #( type capT              // type of the CHERICap capability
   function Bool isLegal (capT cap) =
        hasLegalHardPerms(cap)
     && hasLegalBounds(cap)
+    && hasLegalReservedBits(cap)
     && hasLegalIntMode(cap);
 
 endtypeclass

--- a/CHERICap.bsv
+++ b/CHERICap.bsv
@@ -403,10 +403,15 @@ typeclass CHERICap #( type capT              // type of the CHERICap capability
   // the null capability (requires a dummy proxy)
   function capT nullCapFromDummy (capT dummy);
 
-  // Assert that the encoding is valid
+  // Assert that the bounds encoding is valid
   //////////////////////////////////////////////////////////////////////////////
 
-  function Bool isDerivable (capT cap);
+  function Bool hasLegalBounds (capT cap);
+
+  function Bool isLegal (capT cap) =
+       hasLegalHardPerms(cap)
+    && hasLegalBounds(cap)
+    && hasLegalIntMode(cap);
 
 endtypeclass
 

--- a/CHERICapWrap.bsv
+++ b/CHERICapWrap.bsv
@@ -116,7 +116,7 @@ function Bit#(CapAddrW) `W(getRepresentableLength) (`CAPTYPE dummy, Bit#(CapAddr
 (* noinline *)
 function Bit#(2) `W(getBaseAlignment) (`CAPTYPE cap) = getBaseAlignment(capArg(cap));
 (* noinline *)
-function Bool `W(isDerivable) (`CAPTYPE cap) = isDerivable(capArg(cap));
+function Bool `W(hasLegalBounds) (`CAPTYPE cap) = hasLegalBounds(capArg(cap));
 
 
 


### PR DESCRIPTION
Use one common legalisation function instead of needing to call multiple from Execute stage of the processor